### PR TITLE
Add explicit LTL operators

### DIFF
--- a/src/Pomc/Check.hs
+++ b/src/Pomc/Check.hs
@@ -17,7 +17,7 @@ module Pomc.Check ( fastcheck
 import Pomc.Prop (Prop(..))
 import Pomc.Prec (Prec(..), StructPrecRel, Alphabet)
 import Pomc.Opa (augRun)
-import Pomc.Potl (Formula(..), Dir(..), negative, negation, atomic, normalize, future, getProps)
+import Pomc.Potl (Formula(..), Dir(..), negative, negation, atomic, normalize, getProps)
 import Pomc.Encoding (EncodedSet, PropSet, BitEncoding(..))
 import qualified Pomc.Encoding as E
 import Pomc.PropConv (APType, convPropTokens)
@@ -107,6 +107,8 @@ closure phi otherProps = let  propClos = concatMap (closList . Atomic) (End : ot
       HUntil Up g h   -> [f, Not f] ++ closList g ++ closList h ++ huuExpr g h
       HSince Down g h -> [f, Not f] ++ closList g ++ closList h ++ hsdExpr f g h
       HSince Up g h   -> [f, Not f] ++ closList g ++ closList h ++ hsuExpr g h
+      Next g          -> [f, Not f] ++ closList g
+      GUntil g h      -> [f, Not f] ++ closList g ++ closList h
       Eventually g    -> [f, Not f] ++ closList g
       AuxBack _ g     -> [f, Not f] ++ closList g
       Always _        -> error "Always formulas must be transformed to Eventually formulas."
@@ -145,7 +147,7 @@ makeBitEncoding clos =
 
   in E.newBitEncoding (fetchVec pClosVec) pClosLookup (V.length pClosVec) (V.length pAtomicVec)
 
--- generate encoded atoms from a the closure of phi and all possible inputs
+-- generate encoded atoms from the closure of phi and all possible inputs
 genAtoms :: BitEncoding -> [Formula APType] -> [Input] -> [Atom]
 genAtoms bitenc clos inputs =
   let -- Consistency checks
@@ -157,8 +159,10 @@ genAtoms bitenc clos inputs =
         , onlyif (not . null $ [f | f@(Xor _ _)          <- clos]) (xorCons bitenc clos)
         , onlyif (not . null $ [f | f@(Implies _ _)      <- clos]) (impliesCons bitenc clos)
         , onlyif (not . null $ [f | f@(Iff _ _)          <- clos]) (iffCons bitenc clos)
-        , onlyif (not . null $ [f | f@(Until _ _ _)      <- clos]) (untilCons bitenc clos)
-        , onlyif (not . null $ [f | f@(Since _ _ _)      <- clos]) (sinceCons bitenc clos)
+        , onlyif (not . null $ [f | f@(Until {})         <- clos]) (untilCons bitenc clos)
+        , onlyif (not . null $ [f | f@(GUntil {})        <- clos]) (gUntilCons bitenc clos)
+        , onlyif (not . null $ [f | f@(Eventually _)     <- clos]) (evCons bitenc clos)
+        , onlyif (not . null $ [f | f@(Since {})         <- clos]) (sinceCons bitenc clos)
         , onlyif (not . null $ [f | f@(HUntil Down _ _)  <- clos]) (hierUntilDownCons bitenc clos)
         , onlyif (not . null $ [f | f@(HUntil Up _ _)    <- clos]) (hierUntilUpCons bitenc clos)
         , onlyif (not . null $ [f | f@(HSince Down  _ _) <- clos]) (hierSinceDownCons bitenc clos)
@@ -263,17 +267,36 @@ iffCons bitenc clos set =
 untilCons :: BitEncoding -> [Formula APType] -> EncodedSet -> Bool
 untilCons bitenc clos set = not (E.any bitenc consSet set)
                             &&
-                            -- if h holds or (Until dir g h) still holds in the next (chain) position, then (Until dir g h) must hold in the current atom
+                            -- if h holds or (Until dir g h) still holds in the next (chain) position, then (Until dir g h) holds in the current atom
                             null [f | f@(Until pset g h) <- clos,
                                                             present f pset g h &&
                                                             not (E.member bitenc f set)]
-  where  -- if (Until dir g h) holds, then it must be that h holds or (Until dir g h) still holds in the next (chain) position
+  where  -- if (Until dir g h) holds, then h holds or (g holds and (Until dir g h) still holds in the next (chain) position)
         present u dir g h = E.member bitenc h set
                              || (E.member bitenc g set
                                  && (E.member bitenc (PNext  dir u) set
                                      || E.member bitenc (XNext dir u) set))
         consSet f@(Until dir g h) = not $ present f dir g h
         consSet _ = False
+
+-- consistency check for (GUntil g h)
+gUntilCons :: BitEncoding -> [Formula APType] -> EncodedSet -> Bool
+gUntilCons bitenc clos set = not (E.any bitenc consSet set)
+                            &&
+                            -- if h holds, then (GUntil g h) holds in the current atom
+                            null [f | f@(GUntil _ h) <- clos,
+                                                            E.member bitenc h set &&
+                                                            not (E.member bitenc f set)]
+  where  -- if (GUntil g h) holds, then h holds or g holds
+        consSet (GUntil g h) = not $ E.member bitenc h set || E.member bitenc g set
+        consSet _ = False
+
+-- consistency check for (Eventually g)
+evCons :: BitEncoding -> [Formula APType] -> EncodedSet -> Bool
+evCons bitenc clos set = -- if g holds, (Eventually g) holds as well
+  null [f | f@(Eventually g) <- clos,
+        E.member bitenc g set &&
+        not (E.member bitenc f set)]
 
 -- consistency check for (Since dir g h)
 sinceCons :: BitEncoding -> [Formula APType] -> EncodedSet -> Bool
@@ -358,10 +381,11 @@ pendCombs bitenc clos =
       checkPend _ = False
 
       pendSets = E.powerSet bitenc $ filter checkPend clos
-      combs pset = [(pset, xl, xe, xr) | xl <- [False, True]
-                                       , xe <- [False, True]
-                                       , xr <- [False, True]
-                                       , not (xl && xe)]
+      combs pset = [(pset, xl, xe, xr) |
+                      xl <- [False, True],
+                      xe <- [False, True],
+                      not (xl && xe),
+                      xr <- [False, True]]
   in concatMap combs pendSets
 
 -- given the BitEncoding and the closure of phi,
@@ -401,6 +425,32 @@ initials query bitenc phi clos atoms =
 resolve :: i -> [(i -> Bool, b)] -> [b]
 resolve info conditionals = snd . unzip $ filter (\(cond, _) -> cond info) conditionals
 
+-- Auxiliary functions for when we want to check for an operator
+-- depending on another one
+op2OpMap :: BitEncoding
+              -> [Formula APType]
+              -> (Formula APType -> Formula APType)
+              -> (Formula APType -> Bool)
+              -> [(EncodedSet, EncodedSet, EncodedSet)]
+op2OpMap bitenc cl getAssoc checkOp =
+  map makeMasks $ filter checkOp cl
+  where makeMasks f =
+          let g = getAssoc f
+              gMask = E.singleton bitenc
+                      $ if negative g then negation g else g
+          in ( E.singleton bitenc f -- mask for f
+              , gMask -- mask for g
+              , if negative g then E.empty bitenc else gMask -- how g should be
+              )
+opCheckSet :: BitEncoding
+                -> [(EncodedSet, EncodedSet, EncodedSet)]
+                -> EncodedSet
+                -> EncodedSet
+opCheckSet bitenc op2OpMap baseSet = foldl'
+  (\cset (fMask, gMask, g) -> if E.intersect gMask baseSet == g then E.union cset fMask else cset)
+  (E.empty bitenc)
+  op2OpMap
+
 -- given a BitEncoding, the closure of phi, and the precedence function, generate all Rule groups: (shift rules, push rules, pop rules)
 deltaRules :: BitEncoding -> [Formula APType] -> EncPrecFunc -> (RuleGroup, RuleGroup, RuleGroup)
 deltaRules bitenc cl precFunc =
@@ -423,7 +473,8 @@ deltaRules bitenc cl precFunc =
                                      , (any checkHbu, hbuShiftPr)
                                      , (any checkHbd, hbdShiftPr)
                                      ]
-        , ruleGroupFcrs = resolve cl [ (any checkEv,  evShiftFcr)
+        , ruleGroupFcrs = resolve cl [ (any checkGU,  guShiftFcr),
+                                       (any checkEv,  evShiftFcr)
                                      ]
         , ruleGroupFprs = resolve cl [ (const True,   xrShiftFpr)
                                      , (any checkXnd, xndShiftFpr)
@@ -460,7 +511,8 @@ deltaRules bitenc cl precFunc =
                                      , (any checkHbu, hbuPushPr)
                                      , (any checkHbd, hbdPushPr)
                                      ]
-        , ruleGroupFcrs = resolve cl [ (any checkEv,  evPushFcr)
+        , ruleGroupFcrs = resolve cl [ (any checkGU,  guPushFcr),
+                                       (any checkEv,  evPushFcr)
                                      ]
         , ruleGroupFprs = resolve cl [ (const True,   xrPushFpr)
                                      , (any checkXnd, xndPushFpr)
@@ -492,8 +544,7 @@ deltaRules bitenc cl precFunc =
                                      , (any checkXnu, xnuPopPr)
                                      , (any checkHnu, hnuPopPr)
                                      ]
-        , ruleGroupFcrs = resolve cl [ (any checkEv,  evPopFcr)
-                                     ]
+        , ruleGroupFcrs = resolve cl []
           -- decrease nondeterminism by fixing Xl and Xe when not needed
         , ruleGroupFprs = resolve cl [ (const $ not needXl, xlDisableFpr)
                                      , (const $ not needXe, xeDisableFpr)
@@ -522,31 +573,11 @@ deltaRules bitenc cl precFunc =
         }
   in (shiftGroup, pushGroup, popGroup)
   where
-    -- Auxiliary functions for when we want to check for an operator
-    -- depending on another one
-    makeOp2OpMap :: (Formula APType -> Formula APType)
-                 -> (Formula APType -> Bool)
-                 -> [(EncodedSet, EncodedSet, EncodedSet)]
-    makeOp2OpMap getAssoc checkOp =
-      map makeMasks $ filter checkOp cl
-      where makeMasks f =
-              let g = getAssoc f
-                  gMask = E.singleton bitenc
-                          $ if negative g then negation g else g
-              in ( E.singleton bitenc f -- mask for f
-                 , gMask -- mask for g
-                 , if negative g then E.empty bitenc else gMask -- how g should be
-                 )
-    makeOpCheckSet :: [(EncodedSet, EncodedSet, EncodedSet)]
-                   -> EncodedSet
-                   -> EncodedSet
-    makeOpCheckSet op2OpMap baseSet = foldl'
-      (\cset (fMask, gMask, g) -> if E.intersect gMask baseSet == g then E.union cset fMask else cset)
-      (E.empty bitenc)
-      op2OpMap
+    makeOp2OpMap = op2OpMap bitenc cl
+    makeOpCheckSet = opCheckSet bitenc
 
     -- XL rules :: PrInfo -> Bool
-    -- if no operator needs Xl, we don't case about its value
+    -- if no operator needs Xl, we don't care about its value
     checkXl f = any ($ f) [ checkPn, checkPb, checkXnd, checkXnu, checkXbu
                           , checkHbu, checkHnd, checkHbd
                           , checkHuu, checkHsu, checkHud, checkHsd
@@ -559,7 +590,7 @@ deltaRules bitenc cl precFunc =
     --
 
     -- XE rules :: PrInfo -> Bool
-    -- if no operator needs Xe, we don't case about its value
+    -- if no operator needs Xe, we don't care about its value
     checkXe f = any ($ f) [ checkPn, checkPb
                           , checkHnd, checkHbd, checkHuu, checkHsu, checkHud, checkHsd
                           ]
@@ -1296,6 +1327,29 @@ deltaRules bitenc cl precFunc =
          -- If the next move is a pop and h holds, then HSince Down _ h has to hold
          && (fXl || fXe || ppCurrAbdHsdfs `E.intersect` checkSet == checkSet)
 
+    --  LTL formulae 
+    -- Gu: GUntil g h -- 
+    -- pop transitions do not read any input symbol, so pCurr = fCurr by default in them
+    maskGU = E.suchThat bitenc checkGU
+    checkGU (GUntil {}) = True
+    checkGU _ = False
+
+    guPushFcr :: FcrInfo -> Bool
+    guPushFcr info =
+      let pCurr = current $ fcrState info
+          fCurr = fcrFutureCurr info
+          pCurrGUfs = E.intersect pCurr maskGU
+          gGUh2h = makeOp2OpMap (\(GUntil _ h) -> h) checkGU
+          gGUh2g = makeOp2OpMap (\(GUntil g _) -> g) checkGU
+          pCurrHs = makeOpCheckSet gGUh2h pCurr
+          pCurrGs = makeOpCheckSet gGUh2g pCurr
+          fCurrGUfs = E.intersect fCurr maskGU
+          checkSet = if E.member bitenc (Atomic End) fCurr
+                        then pCurrHs
+                        else pCurrHs `E.union` (pCurrGs `E.intersect` fCurrGUfs)
+      in pCurrGUfs == checkSet
+    guShiftFcr = guPushFcr
+
     -- Ev: Eventually g --
     maskEv = E.suchThat bitenc checkEv
     checkEv (Eventually _) = True
@@ -1307,17 +1361,13 @@ deltaRules bitenc cl precFunc =
           fCurr = fcrFutureCurr info
           pCurrEvfs = E.intersect pCurr maskEv
           evg2g = makeOp2OpMap (\(Eventually g) -> g) checkEv
-          pCheckSet = makeOpCheckSet evg2g pCurr
+          pCheckSet = makeOpCheckSet evg2g pCurr -- a mask for g iff Eventually g
           fCheckSet = E.intersect fCurr maskEv
-          checkSet = E.union pCheckSet fCheckSet
+          checkSet = if E.member bitenc (Atomic End) fCurr
+                      then pCheckSet
+                      else E.union pCheckSet fCheckSet
       in pCurrEvfs ==  checkSet
     evShiftFcr = evPushFcr
-    evPopFcr info =
-      let pCurr = current $ fcrState info
-          fCurr = fcrFutureCurr info
-          pCurrEvfs = E.intersect pCurr maskEv
-          fCheckSet = E.intersect fCurr maskEv
-      in pCurrEvfs ==  fCheckSet
 
 ---------------------------------------------------------------------------------
 -- present
@@ -1450,11 +1500,12 @@ delta rgroup atoms pcombs scombs state mprops mpopped mnextprops
             valid scomb = let info = makeFsrInfo scomb
                           in all ($ info) fsrs
 
-    wfstates = if (pvalid)
-                then [WState curr pend st xl xe xr | curr <- vas,
-                                                     pc@(pend, xl, xe, xr) <- vpcs,
-                                                     st <- vscs,
-                                                     valid curr pc]
+    wfstates = if pvalid
+                then [WState curr pend st xl xe xr |
+                        curr <- vas,
+                        pc@(pend, xl, xe, xr) <- vpcs,
+                        valid curr pc,
+                        st <- vscs]
                 else []
       -- all future rules must be satisfied
       where makeInfo curr pendComb = FrInfo { frState          = state
@@ -1467,13 +1518,13 @@ delta rgroup atoms pcombs scombs state mprops mpopped mnextprops
                                in all ($ info) frs
 
 -- given a BitEncoding, a state formula, determine whether the state is final
-isFinal :: BitEncoding ->  Formula APType -> State  -> Bool
-isFinal bitenc _   s@(FState {}) = isFinalF bitenc s
-isFinal bitenc phi s@(WState {}) = isFinalW bitenc phi s
+isFinal :: BitEncoding -> [Formula APType] -> Formula APType -> State  -> Bool
+isFinal bitenc cl _   s@(FState {}) = isFinalF bitenc cl s
+isFinal bitenc _  phi s@(WState {}) = isFinalW bitenc phi s
 
 isNotTrivialOmega :: Formula APType -> Bool
-isNotTrivialOmega (XNext _ _) = True 
-isNotTrivialOmega (Until _ _ _) = True 
+isNotTrivialOmega (XNext _ _) = True
+isNotTrivialOmega (Until _ _ _) = True
 isNotTrivialOmega (Eventually _) = True
 isNotTrivialOmega _ = False
 
@@ -1494,24 +1545,47 @@ isFinalW bitenc phi@(Eventually g) s =
   (E.member bitenc g (current s)) || (not $ E.member bitenc phi (current s))
 isFinalW _ _ _ = error "called isFinalOmega on a formula for which trivially every state is final"
 
--- given a BitEncoding and a state, determine whether the state is final
-isFinalF :: BitEncoding -> State -> Bool
-isFinalF bitenc s =
+-- given a BitEncoding, a closure and a state, determine whether the state is final
+isFinalF :: BitEncoding -> [Formula APType] -> State -> Bool
+isFinalF bitenc cl s =
   not (mustPush s) -- xe can be instead accepted, as if # = #
   && (not . E.null $ E.intersect currFset maskEnd)
-  && (E.null $ E.intersect currFset maskFuture)
-  && currPend == (E.intersect currPend maskXbu)
+  && pCurrUntilOrEv == pCheckSet
+  && E.null (currFset `E.intersect`  maskOtherFutures)
+  && currPend == (currPend `E.intersect` maskXbu)
   where
     maskEnd = E.singleton bitenc (Atomic End)
-    maskFuture = E.suchThat bitenc future
+    maskOtherFutures = E.suchThat bitenc otherFutures
 
+    maskUntilOrEv = E.suchThat bitenc checkUntilOrEv
+    pCurrUntilOrEv = E.intersect currFset maskUntilOrEv
+    getAssocMap = op2OpMap bitenc cl getAssoc checkUntilOrEv
+    pCheckSet = opCheckSet bitenc getAssocMap currFset
+
+    -- only XBack Up formulas are allowed in pending part of final states
     maskXbu = E.suchThat bitenc checkXbu
     checkXbu (XBack Up _) = True
     checkXbu _ = False
 
     currFset = current s
     currPend = pending s
-    -- only XBack Up formulas are allowed in pending part of final states
+
+    checkUntilOrEv (Until {}) = True
+    checkUntilOrEv (GUntil {}) = True
+    checkUntilOrEv (Eventually _) = True
+    checkUntilOrEv _ = False
+
+    getAssoc (Until _ _ h) = h
+    getAssoc (GUntil _ h) = h
+    getAssoc (Eventually g) = g
+    getAssoc _ = error "not used"
+
+    otherFutures (PNext      {})      = True
+    otherFutures (XNext      {})      = True
+    otherFutures (HNext      {})      = True
+    otherFutures (HUntil     {})      = True
+    otherFutures (Next       _ )      = True
+    otherFutures _ = False
 
 ---------------------------------------------------------------------------------
 -- fastCheck performs trace checking using a lookahead to predict future inputs
@@ -1523,7 +1597,7 @@ fastcheck phi sprs ts =
   augRun
     prec
     is
-    (isFinalF bitenc)
+    (isFinalF bitenc cl)
     (augDeltaShift as pcs scs shiftRules)
     (augDeltaPush  as pcs scs pushRules)
     (augDeltaPop   as pcs scs popRules)
@@ -1597,7 +1671,7 @@ makeOpa phi isOmegaOrProb (sls, sprs) inputFilter =
   ( bitenc
   , prec
   , is
-  , isFinal bitenc
+  , isFinal bitenc cl
   , deltaPush  as pcs scs pushRules  -- apply PushRules
   , deltaShift as pcs scs shiftRules -- apply ShiftRules
   , deltaPop   as pcs scs popRules   -- apply PopRules

--- a/src/Pomc/Encoding.hs
+++ b/src/Pomc/Encoding.hs
@@ -19,9 +19,10 @@ module Pomc.Encoding ( EncodedSet
                      , generateFormulas
                      , powerSet
                      , Pomc.Encoding.null
-                     , Pomc.Encoding.all
+                     , Pomc.Encoding.allSet
                      , member
                      , Pomc.Encoding.any
+                     , Pomc.Encoding.all
                      , Pomc.Encoding.filter
                      , suchThat
                      , intersect
@@ -127,8 +128,8 @@ null (EncodedAtom bv) = bv == BV.nil
 {-# INLINE null #-}
 
 -- test whether all bits are set in the given EncodedAtom
-all :: EncodedAtom -> Bool
-all (EncodedAtom bv) = bv == BV.ones (BV.size bv)
+allSet :: EncodedAtom -> Bool
+allSet (EncodedAtom bv) = bv == BV.ones (BV.size bv)
 
 -- test whether a Formula is part of an EncodedAtom
 member :: BitEncoding -> Formula APType -> EncodedAtom -> Bool
@@ -140,6 +141,11 @@ member bitenc phi (EncodedAtom bv) | negative phi = not $ bv BV.@. (index bitenc
 any :: BitEncoding -> (Formula APType -> Bool) -> EncodedAtom -> Bool
 any bitenc predicate (EncodedAtom bv) = Prelude.any (predicate . (fetch bitenc)) $ listBits bv
 {-# INLINABLE any #-}
+
+-- test whether all formulae in EncodedAtom satisfies rhe predicate
+all :: BitEncoding -> (Formula APType -> Bool) -> EncodedAtom -> Bool
+all bitenc predicate (EncodedAtom bv) = Prelude.all (predicate . (fetch bitenc)) $ listBits bv
+{-# INLINABLE all #-}
 
 -- filter the formulas in an EncodedAtom according to predicate
 filter :: BitEncoding -> (Formula APType -> Bool) -> EncodedAtom -> EncodedAtom

--- a/src/Pomc/ModelChecker.hs
+++ b/src/Pomc/ModelChecker.hs
@@ -103,15 +103,15 @@ modelCheck isOmega phi alphabet inputFilter stateFilter
     encode True = IsOmega
     encode False = IsFinite
     -- generate the OPA associated to the negation of the input formula
-    (bitenc, precFunc, phiInitials, phiIsFinal, phiDeltaPush, phiDeltaShift, phiDeltaPop, cl) =
+    (bitenc, precFunc, phiInitials, (phiIsFinalF, phiIsFinalW), phiDeltaPush, phiDeltaShift, phiDeltaPop, cl) =
       makeOpa (Not phi) (encode isOmega) alphabet inputFilter
 
     -- compute the cartesian product between the initials of the two opas
     cInitials = cartesian opaInitials phiInitials
     -- new isFinal function for the cartesian product:
     -- both underlying opas must be in an acceptance state
-    cIsFinal (MCState q p) = opaIsFinal q && phiIsFinal T p
-    obe = OE.makeOmegaBitEncoding cl (\(MCState q _) -> opaIsFinal q) phiIsFinal
+    cIsFinal (MCState q p) = opaIsFinal q && phiIsFinalF p
+    obe = OE.makeOmegaBitEncoding cl (\(MCState q _) -> opaIsFinal q) phiIsFinalW
 
     cDeltaPush (MCState q p) b =
       cartesianFilter (stateFilter bitenc) (opaDeltaPush bitenc q b) (phiDeltaPush p Nothing)

--- a/src/Pomc/OmegaEncoding.hs
+++ b/src/Pomc/OmegaEncoding.hs
@@ -84,7 +84,7 @@ subsumes oset1 oset2 = E.union (eset oset1) (eset oset2) == (eset oset1)
 -- are all formulae satisfied?
 isSatisfying :: OmegaEncodedSet -> Bool 
 isSatisfying (UnsatModel _) = False 
-isSatisfying (SatModel ea) = E.all ea
+isSatisfying (SatModel ea) = E.allSet ea
 
 -- for debugging purposes
 showOmegaEncoding :: OmegaBitencoding state -> OmegaEncodedSet -> String

--- a/src/Pomc/Parse/Parser.hs
+++ b/src/Pomc/Parse/Parser.hs
@@ -168,6 +168,8 @@ potlP = makeExprParser termParser operatorTable
             , binaryR "Sd" (P.Since P.Down)
             , binaryR "Su" (P.Since P.Up)
 
+            , binaryR "U" P.GUntil
+
             , binaryR "HUd" (P.HUntil P.Down)
             , binaryR "HUu" (P.HUntil P.Up)
             , binaryR "HSd" (P.HSince P.Down)

--- a/src/Pomc/Parse/Parser.hs
+++ b/src/Pomc/Parse/Parser.hs
@@ -148,6 +148,8 @@ potlP = makeExprParser termParser operatorTable
             , prefix "PBd" (P.PBack P.Down)
             , prefix "PBu" (P.PBack P.Up)
 
+            , prefix "N" P.Next
+
             , prefix "XNd" (P.XNext P.Down)
             , prefix "XNu" (P.XNext P.Up)
             , prefix "XBd" (P.XBack P.Down)

--- a/src/Pomc/Prob/ProbEncoding.hs
+++ b/src/Pomc/Prob/ProbEncoding.hs
@@ -71,7 +71,7 @@ subsumes eset1 eset2 = E.union eset1 eset2 == eset1
 
 -- are all formulae satisfied?
 isSatisfying :: EncodedSet -> Bool
-isSatisfying = E.all
+isSatisfying = E.allSet
 
 -- for debugging purposes
 showProbEncoding :: ProBitencoding -> ProbEncodedSet -> String

--- a/src/Pomc/Prob/ProbModelChecker.hs
+++ b/src/Pomc/Prob/ProbModelChecker.hs
@@ -191,7 +191,7 @@ qualitativeModelCheck :: (MonadIO m, MonadFail m, MonadLogger m, Ord s, Hashable
                       -> m (Bool, Stats, String)
 qualitativeModelCheck solver phi alphabet bInitials bDeltaPush bDeltaShift bDeltaPop =
   let
-    (bitenc, precFunc, phiInitials, phiIsFinal, phiDeltaPush, phiDeltaShift, phiDeltaPop, cl) =
+    (bitenc, precFunc, phiInitials, (_, phiIsFinalW), phiDeltaPush, phiDeltaShift, phiDeltaPop, cl) =
       makeOpa phi IsProb alphabet (\_ _ -> True)
 
     deltaPush  = bDeltaPush bitenc
@@ -200,7 +200,7 @@ qualitativeModelCheck solver phi alphabet bInitials bDeltaPush bDeltaShift bDelt
 
     initial = bInitials bitenc
 
-    proEnc = PE.makeProBitEncoding cl phiIsFinal
+    proEnc = PE.makeProBitEncoding cl phiIsFinalW
 
     phiPush p = (phiDeltaPush p Nothing)
     phiShift p = (phiDeltaShift p Nothing)
@@ -343,7 +343,7 @@ quantitativeModelCheck :: (MonadIO m, MonadFail m, MonadLogger m, Ord s, Hashabl
                        -> m ((Prob,Prob), Stats, String)
 quantitativeModelCheck solver phi alphabet bInitials bDeltaPush bDeltaShift bDeltaPop =
   let
-    (bitenc, precFunc, phiInitials, phiIsFinal, phiDeltaPush, phiDeltaShift, phiDeltaPop, cl) =
+    (bitenc, precFunc, phiInitials, (_, phiIsFinalW), phiDeltaPush, phiDeltaShift, phiDeltaPop, cl) =
       makeOpa phi IsProb alphabet (\_ _ -> True)
 
     deltaPush  = bDeltaPush bitenc
@@ -352,7 +352,7 @@ quantitativeModelCheck solver phi alphabet bInitials bDeltaPush bDeltaShift bDel
 
     initial = bInitials bitenc
 
-    proEnc = PE.makeProBitEncoding cl phiIsFinal
+    proEnc = PE.makeProBitEncoding cl phiIsFinalW
 
     phiPush p = (phiDeltaPush p Nothing)
     phiShift p = (phiDeltaShift p Nothing)

--- a/src/Pomc/Satisfiability.hs
+++ b/src/Pomc/Satisfiability.hs
@@ -422,7 +422,7 @@ isSatisfiable isOmega phi alphabet =
   let encode True = IsOmega
       encode False = IsFinite
       
-      (be, precf, initials, isFinal, dPush, dShift, dPop, cl) =
+      (be, precf, initials, (isFinalF, isFinalW), dPush, dShift, dPop, cl) =
         makeOpa phi (encode isOmega) alphabet (\_ _ -> True)
       delta = Delta
         { bitenc = be
@@ -431,10 +431,10 @@ isSatisfiable isOmega phi alphabet =
         , deltaShift = (\q _ -> dShift q Nothing)
         , deltaPop = dPop
         }
-      obe = OE.makeOmegaBitEncoding cl (const True) isFinal
+      obe = OE.makeOmegaBitEncoding cl (const True) isFinalW
       (emptyRes, trace) = if isOmega
                           then isEmptyOmega delta initials obe
-                          else isEmpty delta initials (isFinal T)
+                          else isEmpty delta initials isFinalF
 
   in (not emptyRes, map snd $ toInputTrace be trace)
 

--- a/test/Pomc/Test/TestCheck.hs
+++ b/test/Pomc/Test/TestCheck.hs
@@ -816,6 +816,54 @@ unitTests = testGroup "Unit tests" [potlTests1, potlTests2]
         , stlPrecRelV1
         , map (S.fromList . map Prop) (stlAnnotateV1 ["han", "call", "tbeg", "t", "texc", "t", "ret"])
         )
+      , ( "Accepting Global Until"
+        , True
+        , GUntil T (Atomic . Prop $ "thr")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "han", "thr", "ret"]
+        )
+      , ( "Accepting Global Until - 2"
+        , True
+        , GUntil (Atomic . Prop $ "call") (Atomic . Prop $ "han")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "han", "thr", "ret"]
+        )
+      , ( "Rejecting Global Until"
+        , False
+        , GUntil T (Atomic . Prop $ "thr")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "han", "ret"]
+        )
+      , ( "Rejecting # with a Global Until"
+        , False
+        , GUntil (Atomic . Prop $ "call") (Not . Atomic . Prop $ "call")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "call", "call"]
+        )
+      , ( "Accepting calls Guntil First Ret"
+        , True
+        , GUntil (Atomic . Prop $ "call") (Atomic . Prop $ "ret")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "call", "ret"]
+        )
+      , ( "Accepting Not Global Until"
+        , True
+        , Not $ GUntil (Atomic . Prop $ "call") (Not . Atomic . Prop $ "call")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "call", "call"]
+        )
+      , ( "Rejecting Not Global Until"
+        , False
+        , Not $ GUntil T (Atomic . Prop $ "thr")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "han", "thr", "ret"]
+        )
+      , ( "Accepting Global Until - 3"
+        , True
+        , GUntil T $ Not (Atomic . Prop $ "call")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "han", "thr", "ret"]
+        )
       , ( "Accepting Eventually"
         , True
         , Eventually (Atomic . Prop $ "thr")
@@ -834,7 +882,7 @@ unitTests = testGroup "Unit tests" [potlTests1, potlTests2]
         , stlPrecRelV1
         , map (S.singleton . Prop) ["call", "han", "thr", "ret"]
         )
-      , ( "Accepting Eventually"
+      , ( "Accepting Eventually - 2"
         , True
         , Eventually $ Not (Atomic . Prop $ "call")
         , stlPrecRelV1

--- a/test/Pomc/Test/TestCheck.hs
+++ b/test/Pomc/Test/TestCheck.hs
@@ -816,6 +816,54 @@ unitTests = testGroup "Unit tests" [potlTests1, potlTests2]
         , stlPrecRelV1
         , map (S.fromList . map Prop) (stlAnnotateV1 ["han", "call", "tbeg", "t", "texc", "t", "ret"])
         )
+      , ( "Accepting Global Next"
+        , True
+        , Next (Atomic . Prop $ "han")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "han", "thr", "ret"]
+        )
+      , ( "Accepting Nested Next "
+        , True
+        , Next $ Next (Atomic . Prop $ "thr")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "han", "thr", "ret"]
+        )
+      , ( "Rejecting Next"
+        , False
+        , Next (Atomic . Prop $ "thr")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "han", "ret"]
+        )
+      , ( "Rejecting # with a Global Next"
+        , False
+        , Next (Atomic . Prop $ "call")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call"]
+        )
+      , ( "Rejecting # with a Global Next - 2"
+        , False
+        , Next (Not . Atomic . Prop $ "call")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call"]
+        )
+      , ( "Accepting Not Global Next"
+        , True
+        , Not $ Next (Atomic . Prop $ "call")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "han", "ret"]
+        )
+      , ( "Rejecting Not Global Until"
+        , False
+        , Not $ Next (Atomic . Prop $ "han")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "han", "thr", "ret"]
+        )
+      , ( "Accepting Global Next - 2"
+        , True
+        , Next (Not . Atomic . Prop $ "call")
+        , stlPrecRelV1
+        , map (S.singleton . Prop) ["call", "han", "thr", "ret"]
+        )
       , ( "Accepting Global Until"
         , True
         , GUntil T (Atomic . Prop $ "thr")


### PR DESCRIPTION
Add "GUntil" and "Next" (the usual LTL "X" and "F" operators) to POTL.  Bugfixes in finite-string model checking. 

I did some benchmarking to evaluate the impact of adding the consistency check (phi -> F phi). 
Surprisingly, for large formulae it slows down (about 1%) qualitative mc. I think the reason is that consistency checks are expensive for large formulae because they have big closures. I kept it because it speeds up quantitative model checking because it reduces the number of equations.

























